### PR TITLE
Remove git report slash command #2, make kicking happen in background

### DIFF
--- a/src/commands/ban.rs
+++ b/src/commands/ban.rs
@@ -41,10 +41,7 @@ pub async fn ban(
         return Ok(());
     }
 
-    let result = user_service::ban(ctx.serenity_context(), &user.id, reason.clone()).await?;
-    let response: String;
-    if result {
-        response = format!(
+    let response = format!(
             "{}'s account was banned{}.",
             user.name,
             reason
@@ -52,11 +49,12 @@ pub async fn ban(
                 .map(|r| format!(" for {}", r))
                 .unwrap_or_default()
         );
-    } else {
-        response = "There was a problem banning that user.".to_string();
-    }
 
     ctx.send(CreateReply::default().ephemeral(true).content(response))
         .await?;
+
+    if user_service::ban(ctx.serenity_context(), &user.id, reason.clone()).await.is_err() {
+        ctx.send(CreateReply::default().ephemeral(true).content("There was an issue banning that user.")).await?;
+    }
     Ok(())
 }

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -10,7 +10,7 @@ use ::serenity::all::{CreateEmbed, CreateMessage};
 use poise::serenity_prelude as serenity;
 
 /// Report a message
-#[poise::command(context_menu_command = "Report to Banshee", slash_command)]
+#[poise::command(context_menu_command = "Report to Banshee")]
 pub async fn report(
     ctx: types::Context<'_>,
     #[description = "Message to Report"] msg: serenity::Message,


### PR DESCRIPTION
- Fixes #2, because unfortunately using /report <message_id> won't work without the message content intent which needs to be applied for.
- When running /ban, send the ban message immediately, and do the kicking in the background.

These combined should add the slight optimizations that will allow Banshee to support more servers.
